### PR TITLE
Fix Linux Create Syslink Root Problem

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -103,7 +103,7 @@ if ! mv "$SUPAGEN_DIR/supagen" "$SUPAGEN_DIR_BIN"; then
 fi
 
 # Create a symlink
-if ! ln -sf "$SUPAGEN_DIR_BIN/supagen" "$SYMLINK_TARGET"; then
+if ! sudo ln -sf "$SUPAGEN_DIR_BIN/supagen" "$SYMLINK_TARGET"; then
     error "Failed to create symlink."
 fi
 


### PR DESCRIPTION
Currently on linux when we install using sh script with sudo, it will redirect to root and need to run supagen with sudo because it changed the $HOME into /root.

![image](https://github.com/user-attachments/assets/4c6aa47f-64d0-416f-8a51-54aa9a2a162f)

for this need to add sudo to the command instead .
After fix will now ask the password after command. This should work the same with macos

![image](https://github.com/user-attachments/assets/460d3e05-1a85-4ad4-9e09-42f785a09db7)
